### PR TITLE
Add GitHub workflow to run a simple `cargo build`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,52 @@
+name: Simple debug build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+  LLVM_VERSION: 16.0.4
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+
+          - os: ubuntu-latest
+            llvm_url: https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-22.04.tar.xz
+
+        # No pre-built binaries for amd64 macOS :<
+        #
+        #   - os: macos-latest
+        #     llvm_url: https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-arm64-apple-darwin22.0.tar.xz
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Cache pre-built binaries of LLVM
+      id: cache-llvm
+      uses: actions/cache@v2
+      with:
+        path: llvm
+        key: llvm-${{ env.LLVM_VERSION }}-${{ matrix.os }}
+
+    - name: Download and extract pre-built LLVM release
+      if: steps.cache-llvm.outputs.cache-hit == 'false'
+      run: |
+        mkdir -p llvm
+        curl -L ${{ matrix.llvm_url }} | tar xJ --strip-components=1 -C llvm
+
+    - name: Add extracted LLVM binaries to PATH
+      run: echo "$GITHUB_WORKSPACE/llvm/bin" >> $GITHUB_PATH
+
+    - name: Build
+      run: cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,16 @@ jobs:
         path: llvm
         key: llvm-${{ env.LLVM_VERSION }}-${{ matrix.os }}
 
+    - name: Cache of Cargo registry and build artifacts
+      id: cache-rust
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: rust-${{ env.LLVM_VERSION }}-${{ matrix.os }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Download and extract pre-built LLVM release
       if: steps.cache-llvm.outputs.cache-hit != 'true'
       run: |
@@ -50,13 +60,3 @@ jobs:
 
     - name: Debug build of Raku from repo root
       run: cargo build
-
-    - name: Cache pre-built binaries of LLVM
-      id: cache-rust
-      uses: actions/cache@v2
-      with:
-        path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-        key: rust-${{ env.LLVM_VERSION }}-${{ matrix.os }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
         key: llvm-${{ env.LLVM_VERSION }}-${{ matrix.os }}
 
     - name: Download and extract pre-built LLVM release
-      if: steps.cache-llvm.outputs.cache-hit == 'false'
+      if: steps.cache-llvm.outputs.cache-hit != 'true'
       run: |
         mkdir -p llvm
         curl -L ${{ matrix.llvm_url }} | tar xJ --strip-components=1 -C llvm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,9 @@ jobs:
       id: cache-llvm
       uses: actions/cache@v2
       with:
-        path: llvm
+        path: |
+          llvm/bin/lld
+          llvm/bin/ld.lld
         key: llvm-${{ env.LLVM_VERSION }}-${{ matrix.os }}
 
     - name: Cache of Cargo registry and build artifacts

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,10 +46,11 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
+          ~/.cargo/bin
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: rust-${{ env.LLVM_VERSION }}-${{ matrix.os }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}
+        key: rust-${{ env.LLVM_VERSION }}-${{ matrix.os }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock', 'rust-toolchain.toml', '**/config.toml') }}
 
     - name: Download and extract pre-built LLVM release
       if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Simple debug build
+name: Debug build that doesn't produce a ROM
 
 on:
   push:
@@ -48,5 +48,15 @@ jobs:
     - name: Add extracted LLVM binaries to PATH
       run: echo "$GITHUB_WORKSPACE/llvm/bin" >> $GITHUB_PATH
 
-    - name: Build
+    - name: Debug build of Raku from repo root
       run: cargo build
+
+    - name: Cache pre-built binaries of LLVM
+      id: cache-rust
+      uses: actions/cache@v2
+      with:
+        path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+        key: rust-${{ env.LLVM_VERSION }}-${{ matrix.os }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
Runs `cargo build` on all pushes and pull requests. Note that command run at
the root of the repo, isn't sufficient to build the ROM artifact; see the README.