### PR TITLE
Interlaced 640x480 with more test image improvements

### DIFF
--- a/kernel/src/dev/rdp/interface.rs
+++ b/kernel/src/dev/rdp/interface.rs
@@ -49,7 +49,9 @@ bitfield! {
     pub struct RDPStatusAsRead(pub u32): IntoRaw, FromRaw {
         pub start_pending: bool @ 10,
         pub end_pending: bool @ 9,
-        pub busy: bool @ 6,
+        pub buffer_busy: bool @ 7,
+        pub command_busy: bool @ 6,
+        pub pipe_busy: bool @ 5,
         pub flush: bool @ 2,
         pub freeze: bool @ 1,
         pub source: bool [DMATransferSource] @ 0,

--- a/kernel/src/dev/vi.rs
+++ b/kernel/src/dev/vi.rs
@@ -200,7 +200,13 @@ bitfield! {
 
 bitfield! {
 
-    /// Width of the frame buffer in pixels
+    /// Width in pixels of a full line of a frame in the frame buffer.
+    ///
+    /// If using progressive scan (e.g. 240p), lines are only made up
+    /// only one "field" is projected (e.g. width of 320px). If using
+    /// interlace scan (e.g. 480i), lines are made up of even and odd
+    /// "fields" (e.g. width of 640 * 2 = 1280px). This register seems
+    /// involved with how frame pixels are sampled and scaled.
     ///
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct VI_WIDTH(pub u32): IntoRaw, FromRaw {


### PR DESCRIPTION
    Changes:
    - Interlacing without interrupts
    - Added dim hue bars on the test image
    - Keep frame buffer 1 untouched, use fb2

    Notes:
    - Since the test image is still, use Weave deinterlacing.
    - There is a weird phenomena where the busy bit of the RDP
      goes false but data continues to be written to the frame
      buffer, resulting in artifacts. This is worked around by
      drawing the CPU content again after a second frame swap.
      More investigation is needed.